### PR TITLE
Use unix timestamp in timestamp field.

### DIFF
--- a/gelf.go
+++ b/gelf.go
@@ -51,7 +51,7 @@ func (a *GelfAdapter) Stream(logstream chan *router.Message) {
 			Version:        "1.1",
       			Host:           hostname, // Running as a container cannot discover the Docker Hostname
 			ShortMessage:   m.Data,
-			Timestamp:      m.Time.Format(time.RFC3339Nano),
+			Timestamp:      m.Time.Unix(),
 			ContainerId:    m.Container.ID,
 			ContainerName:  m.Container.Name,
 			ContainerCmd:   strings.Join(m.Container.Config.Cmd," "),
@@ -85,7 +85,7 @@ type GelfMessage struct {
 	Host         string  `json:"host,omitempty"`
 	ShortMessage string  `json:"short_message"`
 	FullMessage  string  `json:"message,omitempty"`
-	Timestamp    string  `json:"timestamp,omitempty"`
+	Timestamp    int     `json:"timestamp,omitempty"`
 	Level        int     `json:"level,omitempty"`
 
 	ImageId        string `json:"image_id,omitempty"`


### PR DESCRIPTION
Graylog version 2.3 now validates the timestamp and it does not accept strings like this module is sending eg. "2017-08-14T12:54:42.684175662Z". It should be the unix timestamp, as per the documentation here: http://docs.graylog.org/en/2.3/pages/gelf.html